### PR TITLE
Cookies saving token instead of id

### DIFF
--- a/spec/Context/WishlistContextSpec.php
+++ b/spec/Context/WishlistContextSpec.php
@@ -67,10 +67,10 @@ final class WishlistContextSpec extends ObjectBehavior
         WishlistInterface $wishlist
     ): void {
         $request->cookies = $parameterBag;
-        $parameterBag->get('bitbag_sylius_wishlist')->willReturn(1);
+        $parameterBag->get('bitbag_sylius_wishlist')->willReturn("Fq8N4W6mk12i9J2HX0U60POGG5UEzSgGW37OWd6sv2dd8FlBId");
         $tokenStorage->getToken()->willReturn($token);
         $token->getUser()->willReturn(null);
-        $wishlistRepository->find(1)->willReturn($wishlist);
+        $wishlistRepository->findByToken("Fq8N4W6mk12i9J2HX0U60POGG5UEzSgGW37OWd6sv2dd8FlBId")->willReturn($wishlist);
 
         $this->getWishlist($request)->shouldReturn($wishlist);
     }
@@ -85,10 +85,10 @@ final class WishlistContextSpec extends ObjectBehavior
         WishlistInterface $wishlist
     ): void {
         $request->cookies = $parameterBag;
-        $parameterBag->get('bitbag_sylius_wishlist')->willReturn(1);
+        $parameterBag->get('bitbag_sylius_wishlist')->willReturn("Fq8N4W6mk12i9J2HX0U60POGG5UEzSgGW37OWd6sv2dd8FlBId");
         $tokenStorage->getToken()->willReturn($token);
         $token->getUser()->willReturn(null);
-        $wishlistRepository->find(1)->willReturn(null);
+        $wishlistRepository->findByToken("Fq8N4W6mk12i9J2HX0U60POGG5UEzSgGW37OWd6sv2dd8FlBId")->willReturn(null);
         $wishlistFactory->createNew()->willReturn($wishlist);
 
         $this->getWishlist($request)->shouldReturn($wishlist);

--- a/spec/Controller/Action/AddProductToWishlistActionSpec.php
+++ b/spec/Controller/Action/AddProductToWishlistActionSpec.php
@@ -39,7 +39,7 @@ final class AddProductToWishlistActionSpec extends ObjectBehavior
             $flashBag,
             $translator,
             $urlGenerator,
-            'bitbag_wishlist_id'
+            'bitbag_wishlist_token'
         );
     }
 
@@ -81,7 +81,7 @@ final class AddProductToWishlistActionSpec extends ObjectBehavior
         $wishlistManager->persist($wishlist)->shouldBeCalled();
         $wishlistManager->flush()->shouldBeCalled();
         $flashBag->add('success', 'Product has been added to your wishlist.')->shouldBeCalled();
-        $wishlist->getId()->shouldBeCalled();
+        $wishlist->getToken()->shouldBeCalled();
 
         $this->__invoke($request)->shouldHaveType(RedirectResponse::class);
     }

--- a/spec/EventListener/MergeUserWishlistItemsListenerSpec.php
+++ b/spec/EventListener/MergeUserWishlistItemsListenerSpec.php
@@ -69,8 +69,8 @@ final class MergeUserWishlistItemsListenerSpec extends ObjectBehavior
         $token->getUser()->willReturn($shopUser);
         $interactiveLoginEvent->getRequest()->willReturn($request);
         $request->cookies = $parameterBag;
-        $parameterBag->get('bitbag_sylius_wishlist')->willReturn(1);
-        $wishlistRepository->find(1)->willReturn($cookieWishlist);
+        $parameterBag->get('bitbag_sylius_wishlist')->willReturn("Fq8N4W6mk12i9J2HX0U60POGG5UEzSgGW37OWd6sv2dd8FlBId");
+        $wishlistRepository->findByToken("Fq8N4W6mk12i9J2HX0U60POGG5UEzSgGW37OWd6sv2dd8FlBId")->willReturn($cookieWishlist);
         $wishlistRepository->findByShopUser($shopUser)->willReturn($userWishlist);
         $cookieWishlist->getWishlistProducts()->willReturn(new ArrayCollection([$wishlistProduct->getWrappedObject()]));
 
@@ -94,8 +94,8 @@ final class MergeUserWishlistItemsListenerSpec extends ObjectBehavior
         $token->getUser()->willReturn($shopUser);
         $interactiveLoginEvent->getRequest()->willReturn($request);
         $request->cookies = $parameterBag;
-        $parameterBag->get('bitbag_sylius_wishlist')->willReturn(1);
-        $wishlistRepository->find(1)->willReturn($cookieWishlist);
+        $parameterBag->get('bitbag_sylius_wishlist')->willReturn("Fq8N4W6mk12i9J2HX0U60POGG5UEzSgGW37OWd6sv2dd8FlBId");
+        $wishlistRepository->findByToken("Fq8N4W6mk12i9J2HX0U60POGG5UEzSgGW37OWd6sv2dd8FlBId")->willReturn($cookieWishlist);
         $wishlistRepository->findByShopUser($shopUser)->willReturn(null);
 
         $cookieWishlist->setShopUser($shopUser)->shouldBeCalled();

--- a/src/Context/WishlistContext.php
+++ b/src/Context/WishlistContext.php
@@ -31,33 +31,33 @@ final class WishlistContext implements WishlistContextInterface
     private $wishlistFactory;
 
     /** @var string */
-    private $wishlistCookieId;
+    private $wishlistCookieToken;
 
     public function __construct(
         TokenStorageInterface $tokenStorage,
         WishlistRepositoryInterface $wishlistRepository,
         WishlistFactoryInterface $wishlistFactory,
-        string $wishlistCookieId
+        string $wishlistCookieToken
     ) {
         $this->tokenStorage = $tokenStorage;
         $this->wishlistRepository = $wishlistRepository;
         $this->wishlistFactory = $wishlistFactory;
-        $this->wishlistCookieId = $wishlistCookieId;
+        $this->wishlistCookieToken = $wishlistCookieToken;
     }
 
     public function getWishlist(Request $request): WishlistInterface
     {
-        $cookieWishlistId = $request->cookies->get($this->wishlistCookieId);
+        $cookieWishlistToken = $request->cookies->get($this->wishlistCookieToken);
         $token = $this->tokenStorage->getToken();
         $user = $token ? $token->getUser() : null;
 
-        if (null === $cookieWishlistId && null === $user) {
+        if (null === $cookieWishlistToken && null === $user) {
             return $this->wishlistFactory->createNew();
         }
 
-        if (null !== $cookieWishlistId && !$user instanceof ShopUserInterface) {
-            return $this->wishlistRepository->find($cookieWishlistId) ?
-                $this->wishlistRepository->find($cookieWishlistId) :
+        if (null !== $cookieWishlistToken && !$user instanceof ShopUserInterface) {
+            return $this->wishlistRepository->find($cookieWishlistToken) ?
+                $this->wishlistRepository->find($cookieWishlistToken) :
                 $this->wishlistFactory->createNew()
             ;
         }

--- a/src/Context/WishlistContext.php
+++ b/src/Context/WishlistContext.php
@@ -56,8 +56,8 @@ final class WishlistContext implements WishlistContextInterface
         }
 
         if (null !== $cookieWishlistToken && !$user instanceof ShopUserInterface) {
-            return $this->wishlistRepository->find($cookieWishlistToken) ?
-                $this->wishlistRepository->find($cookieWishlistToken) :
+            return $this->wishlistRepository->findByToken($cookieWishlistToken) ?
+                $this->wishlistRepository->findByToken($cookieWishlistToken) :
                 $this->wishlistFactory->createNew()
             ;
         }

--- a/src/Controller/Action/AddProductToWishlistAction.php
+++ b/src/Controller/Action/AddProductToWishlistAction.php
@@ -51,7 +51,7 @@ final class AddProductToWishlistAction
     private $urlGenerator;
 
     /** @var string */
-    private $wishlistCookieId;
+    private $wishlistCookieToken;
 
     public function __construct(
         ProductRepositoryInterface $productRepository,
@@ -61,14 +61,14 @@ final class AddProductToWishlistAction
         FlashBagInterface $flashBag,
         TranslatorInterface $translator,
         UrlGeneratorInterface $urlGenerator,
-        string $wishlistCookieId
+        string $wishlistCookieToken
     ) {
         $this->productRepository = $productRepository;
         $this->wishlistContext = $wishlistContext;
         $this->wishlistProductFactory = $wishlistProductFactory;
         $this->wishlistManager = $wishlistManager;
         $this->urlGenerator = $urlGenerator;
-        $this->wishlistCookieId = $wishlistCookieId;
+        $this->wishlistCookieToken = $wishlistCookieToken;
         $this->flashBag = $flashBag;
         $this->translator = $translator;
     }
@@ -95,7 +95,7 @@ final class AddProductToWishlistAction
         $this->wishlistManager->flush();
         $this->flashBag->add('success', $this->translator->trans('bitbag_sylius_wishlist_plugin.ui.added_wishlist_item'));
 
-        $cookie = new Cookie($this->wishlistCookieId, $wishlist->getId(), strtotime('+1 year'));
+        $cookie = new Cookie($this->wishlistCookieToken, $wishlist->getToken(), strtotime('+1 year'));
         $response = new RedirectResponse($this->urlGenerator->generate('bitbag_sylius_wishlist_plugin_shop_wishlist_list_products'));
         $response->headers->setCookie($cookie);
 

--- a/src/Entity/Wishlist.php
+++ b/src/Entity/Wishlist.php
@@ -16,6 +16,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class Wishlist implements WishlistInterface
 {
@@ -28,9 +29,13 @@ class Wishlist implements WishlistInterface
     /** @var ShopUserInterface|null */
     protected $shopUser;
 
+    /** @var TokenInterface|null */
+    protected $token;
+
     public function __construct()
     {
         $this->wishlistProducts = new ArrayCollection();
+        $this->token = new WishlistToken();
     }
 
     public function getId(): ?int
@@ -86,5 +91,15 @@ class Wishlist implements WishlistInterface
     public function setShopUser(ShopUserInterface $shopUser): void
     {
         $this->shopUser = $shopUser;
+    }
+
+    public function getToken(): string
+    {
+        return $this->token->getValue();
+    }
+
+    public function setToken(string $token): void
+    {
+        $this->token->setValue($token);
     }
 }

--- a/src/Entity/Wishlist.php
+++ b/src/Entity/Wishlist.php
@@ -95,11 +95,11 @@ class Wishlist implements WishlistInterface
 
     public function getToken(): string
     {
-        return $this->token->getValue();
+        return (string) $this->token;
     }
 
     public function setToken(string $token): void
     {
-        $this->token->setValue($token);
+        $this->token = new WishlistToken($token);
     }
 }

--- a/src/Entity/WishlistInterface.php
+++ b/src/Entity/WishlistInterface.php
@@ -16,6 +16,7 @@ use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 interface WishlistInterface extends ResourceInterface
 {
@@ -38,4 +39,8 @@ interface WishlistInterface extends ResourceInterface
     public function getShopUser(): ?ShopUserInterface;
 
     public function setShopUser(ShopUserInterface $shopShopUser): void;
+
+    public function getToken(): string;
+
+    public function setToken(string $token): void;
 }

--- a/src/Entity/WishlistInterface.php
+++ b/src/Entity/WishlistInterface.php
@@ -16,7 +16,6 @@ use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 interface WishlistInterface extends ResourceInterface
 {

--- a/src/Entity/WishlistToken.php
+++ b/src/Entity/WishlistToken.php
@@ -1,16 +1,20 @@
 <?php
+
 declare(strict_types=1);
 
 namespace BitBag\SyliusWishlistPlugin\Entity;
-
 
 class WishlistToken implements WishlistTokenInterface
 {
     protected $value;
 
-    public function __construct()
+    public function __construct(?string $value = null)
     {
-        $this->value = $this->generate(50);
+        if ($value === null) {
+            $this->value = $this->generate(self::VALUE_LENGTH);
+        } else {
+            $this->setValue($value);
+        }
     }
 
     public function getValue(): string
@@ -30,14 +34,14 @@ class WishlistToken implements WishlistTokenInterface
 
     private function generate($length): string
     {
-        $token = "";
-        $codeAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-        $codeAlphabet.= "abcdefghijklmnopqrstuvwxyz";
-        $codeAlphabet.= "0123456789";
+        $token = '';
+        $codeAlphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        $codeAlphabet .= 'abcdefghijklmnopqrstuvwxyz';
+        $codeAlphabet .= '0123456789';
         $max = strlen($codeAlphabet); // edited
 
-        for ($i=0; $i < $length; $i++) {
-            $token .= $codeAlphabet[random_int(0, $max-1)];
+        for ($i = 0; $i < $length; ++$i) {
+            $token .= $codeAlphabet[random_int(0, $max - 1)];
         }
 
         return $token;

--- a/src/Entity/WishlistToken.php
+++ b/src/Entity/WishlistToken.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace BitBag\SyliusWishlistPlugin\Entity;
+
+
+class WishlistToken implements WishlistTokenInterface
+{
+    protected $value;
+
+    public function __construct()
+    {
+        $this->value = $this->generate(50);
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function setValue(string $value): void
+    {
+        $this->value = $value;
+    }
+
+    public function __toString()
+    {
+        return $this->getValue();
+    }
+
+    private function generate($length): string
+    {
+        $token = "";
+        $codeAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        $codeAlphabet.= "abcdefghijklmnopqrstuvwxyz";
+        $codeAlphabet.= "0123456789";
+        $max = strlen($codeAlphabet); // edited
+
+        for ($i=0; $i < $length; $i++) {
+            $token .= $codeAlphabet[random_int(0, $max-1)];
+        }
+
+        return $token;
+    }
+}

--- a/src/Entity/WishlistTokenInterface.php
+++ b/src/Entity/WishlistTokenInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace BitBag\SyliusWishlistPlugin\Entity;
+
+interface WishlistTokenInterface
+{
+    public function getValue(): string;
+
+    public function setValue(string $value): void;
+}

--- a/src/Entity/WishlistTokenInterface.php
+++ b/src/Entity/WishlistTokenInterface.php
@@ -1,10 +1,13 @@
 <?php
+
 declare(strict_types=1);
 
 namespace BitBag\SyliusWishlistPlugin\Entity;
 
 interface WishlistTokenInterface
 {
+    const VALUE_LENGTH = 50;
+
     public function getValue(): string;
 
     public function setValue(string $value): void;

--- a/src/EventListener/MergeUserWishlistItemsListener.php
+++ b/src/EventListener/MergeUserWishlistItemsListener.php
@@ -32,18 +32,18 @@ final class MergeUserWishlistItemsListener
     private $wishlistManager;
 
     /** @var string */
-    private $wishlistCookieId;
+    private $wishlistCookieToken;
 
     public function __construct(
         WishlistRepositoryInterface $wishlistRepository,
         WishlistFactoryInterface $wishlistFactory,
         EntityManagerInterface $wishlistManager,
-        string $wishlistCookieId
+        string $wishlistCookieToken
     ) {
         $this->wishlistRepository = $wishlistRepository;
         $this->wishlistFactory = $wishlistFactory;
         $this->wishlistManager = $wishlistManager;
-        $this->wishlistCookieId = $wishlistCookieId;
+        $this->wishlistCookieToken = $wishlistCookieToken;
     }
 
     public function onInteractiveLogin(InteractiveLoginEvent $interactiveLoginEvent): void
@@ -58,9 +58,9 @@ final class MergeUserWishlistItemsListener
 
     private function resolveWishlist(Request $request, ShopUserInterface $shopUser): void
     {
-        $cookieWishlistId = $request->cookies->get($this->wishlistCookieId);
+        $cookieWishlistToken = $request->cookies->get($this->wishlistCookieToken);
         /** @var WishlistInterface|null $cookieWishlist */
-        $cookieWishlist = $this->wishlistRepository->find($cookieWishlistId);
+        $cookieWishlist = $this->wishlistRepository->findByToken($cookieWishlistToken);
         $userWishlist = $this->wishlistRepository->findByShopUser($shopUser);
 
         if (null === $cookieWishlist) {

--- a/src/Repository/WishlistRepository.php
+++ b/src/Repository/WishlistRepository.php
@@ -27,4 +27,14 @@ class WishlistRepository extends EntityRepository implements WishlistRepositoryI
             ->getOneOrNullResult()
         ;
     }
+
+    public function findByToken(string $token): ?WishlistInterface
+    {
+        return $this->createQueryBuilder('o')
+            ->where('o.token = :token')
+            ->setParameter('token', $token)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
 }

--- a/src/Repository/WishlistRepositoryInterface.php
+++ b/src/Repository/WishlistRepositoryInterface.php
@@ -19,4 +19,6 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 interface WishlistRepositoryInterface extends RepositoryInterface
 {
     public function findByShopUser(ShopUserInterface $shopUser): ?WishlistInterface;
+
+    public function findByToken(string $token): ?WishlistInterface;
 }

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -1,5 +1,5 @@
 parameters:
-    wishlist_cookie_id: bitbag_sylius_wishlist
+    wishlist_cookie_token: bitbag_sylius_wishlist
 
 imports:
     - { resource: "@BitBagSyliusWishlistPlugin/Resources/config/services.yml" }

--- a/src/Resources/config/doctrine/Wishlist.orm.xml
+++ b/src/Resources/config/doctrine/Wishlist.orm.xml
@@ -10,6 +10,8 @@
             <generator strategy="AUTO" />
         </id>
 
+        <field name="token" type="string" column="token" />
+
         <one-to-many field="wishlistProducts" target-entity="BitBag\SyliusWishlistPlugin\Entity\WishlistProductInterface" mapped-by="wishlist">
             <cascade>
                 <cascade-all/>

--- a/src/Resources/config/doctrine/Wishlist.orm.xml
+++ b/src/Resources/config/doctrine/Wishlist.orm.xml
@@ -10,7 +10,7 @@
             <generator strategy="AUTO" />
         </id>
 
-        <field name="token" type="string" column="token" />
+        <field name="token" type="string" column="token" unique="true" />
 
         <one-to-many field="wishlistProducts" target-entity="BitBag\SyliusWishlistPlugin\Entity\WishlistProductInterface" mapped-by="wishlist">
             <cascade>

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -9,7 +9,7 @@ services:
             - "@session.flash_bag"
             - "@translator"
             - "@router"
-            - "%wishlist_cookie_id%"
+            - "%wishlist_cookie_token%"
 
     bitbag_sylius_wishlist_plugin.controller.action.remove_product_from_wishlist:
         class: BitBag\SyliusWishlistPlugin\Controller\Action\RemoveProductFromWishlistAction
@@ -45,7 +45,8 @@ services:
             - "@security.token_storage"
             - "@bitbag_sylius_wishlist_plugin.repository.wishlist"
             - "@bitbag_sylius_wishlist_plugin.factory.wishlist"
-            - "%wishlist_cookie_id%"
+            - "%wishlist_cookie_token%"
+            - "%wishlist_cookie_token%"
 
     bitbag_sylius_wishlist_plugin.custom_factory.wishlist:
         class: BitBag\SyliusWishlistPlugin\Factory\WishlistFactory
@@ -67,7 +68,7 @@ services:
             - "@bitbag_sylius_wishlist_plugin.repository.wishlist"
             - "@bitbag_sylius_wishlist_plugin.factory.wishlist"
             - "@bitbag_sylius_wishlist_plugin.manager.wishlist"
-            - "%wishlist_cookie_id%"
+            - "%wishlist_cookie_token%"
         tags:
             - { name: kernel.event_listener, event: security.interactive_login, method: onInteractiveLogin }
 

--- a/tests/Behat/Context/Setup/WishlistContext.php
+++ b/tests/Behat/Context/Setup/WishlistContext.php
@@ -52,7 +52,7 @@ final class WishlistContext implements Context
     private $cookieSetter;
 
     /** @var string */
-    private $wishlistCookieId;
+    private $wishlistCookieToken;
 
     public function __construct(
         ProductRepositoryInterface $productRepository,
@@ -63,7 +63,7 @@ final class WishlistContext implements Context
         FactoryInterface $productTaxonFactory,
         EntityManagerInterface $productTaxonManager,
         CookieSetterInterface $cookieSetter,
-        string $wishlistCookieId
+        string $wishlistCookieToken
     ) {
         $this->productRepository = $productRepository;
         $this->wishlistContext = $wishlistContext;
@@ -73,7 +73,7 @@ final class WishlistContext implements Context
         $this->productTaxonFactory = $productTaxonFactory;
         $this->productTaxonManager = $productTaxonManager;
         $this->cookieSetter = $cookieSetter;
-        $this->wishlistCookieId = $wishlistCookieId;
+        $this->wishlistCookieToken = $wishlistCookieToken;
     }
 
     /**
@@ -137,6 +137,6 @@ final class WishlistContext implements Context
         $this->wishlistManager->persist($wishlist);
         $this->wishlistManager->flush();
 
-        $this->cookieSetter->setCookie($this->wishlistCookieId, $wishlist->getId());
+        $this->cookieSetter->setCookie($this->wishlistCookieToken, $wishlist->getToken());
     }
 }

--- a/tests/Behat/Page/Shop/ProductIndexPage.php
+++ b/tests/Behat/Page/Shop/ProductIndexPage.php
@@ -19,6 +19,8 @@ class ProductIndexPage extends IndexPage implements ProductIndexPageInterface
 {
     public function addProductToWishlist(string $productName): void
     {
+        $this->getSession()->setCookie('MOCKSESSID', 'foo');
+
         $wishlistElements = $this->getDocument()->findAll('css', '.bitbag-add-to-wishlist');
 
         /** @var NodeElement $wishlistElement */

--- a/tests/Behat/Resources/services.yml
+++ b/tests/Behat/Resources/services.yml
@@ -10,7 +10,7 @@ services:
             - "@__symfony__.sylius.factory.product_taxon"
             - "@__symfony__.sylius.manager.product_taxon"
             - "@sylius.behat.cookie_setter"
-            - "%__symfony__.wishlist_cookie_id%"
+            - "%__symfony__.wishlist_cookie_token%"
         tags:
             - { name: fob.context_service }
 


### PR DESCRIPTION
Before, the cookie stored the id of the wishlist, but that's not very secure. 
A visitor could just guess numbers, setting the value of the cookie, until he finds a wishlist of another customer and mess with it.

So now, instead of storing the id, the cookie stores a random 50 character long token which gets associated with the wishlist.