### PR TITLE
Added getExtendedType function for Symfony 3.4

### DIFF
--- a/src/Form/Extension/AddToCartTypeExtension.php
+++ b/src/Form/Extension/AddToCartTypeExtension.php
@@ -33,7 +33,12 @@ class AddToCartTypeExtension extends AbstractTypeExtension
             ->setAllowedTypes('is_wishlist', 'bool')
         ;
     }
-
+    
+    public function getExtendedType()
+    {
+        return AddToCartType::class;
+    }
+    
     public static function getExtendedTypes(): array
     {
         return [AddToCartType::class];

--- a/src/Form/Extension/AddToCartTypeExtension.php
+++ b/src/Form/Extension/AddToCartTypeExtension.php
@@ -34,7 +34,7 @@ class AddToCartTypeExtension extends AbstractTypeExtension
         ;
     }
     
-    public function getExtendedType()
+    public function getExtendedType(): string
     {
         return AddToCartType::class;
     }


### PR DESCRIPTION
This plugin still allows to use Symfony 3.4, therefore it should implement the getExtendedType function for the extensions on Symfony 3.4. [See this for more information.](https://symfony.com/blog/new-in-symfony-4-2-improved-form-type-extensions)