### PR TITLE
Cascade wishlist on user deletion

### DIFF
--- a/src/Resources/config/doctrine/Wishlist.orm.xml
+++ b/src/Resources/config/doctrine/Wishlist.orm.xml
@@ -19,7 +19,7 @@
         </one-to-many>
 
         <one-to-one field="shopUser" target-entity="Sylius\Component\Core\Model\ShopUserInterface">
-            <join-column name="shop_user_id" referenced-column-name="id" nullable="true" />
+            <join-column name="shop_user_id" referenced-column-name="id" nullable="true" on-delete="CASCADE" />
         </one-to-one>
 
     </mapped-superclass>


### PR DESCRIPTION
Right now it is impossible to delete a user that has a wishlist.
To make this possible, the wishlist has to cascade the user deletion.