### PR TITLE
Fix doctrine migrations_paths order

### DIFF
--- a/src/DependencyInjection/BitBagSyliusWishlistExtension.php
+++ b/src/DependencyInjection/BitBagSyliusWishlistExtension.php
@@ -26,6 +26,7 @@ final class BitBagSyliusWishlistExtension extends AbstractResourceExtension impl
 
     public function prepend(ContainerBuilder $container): void
     {
+        trigger_deprecation('bitbag/wishlist-plugin', '2.0', 'Doctrine migrations existing in a bundle will be removed, move migrations to the project directory.');
         $this->prependDoctrineMigrations($container);
     }
 

--- a/src/DependencyInjection/BitBagSyliusWishlistExtension.php
+++ b/src/DependencyInjection/BitBagSyliusWishlistExtension.php
@@ -27,10 +27,15 @@ final class BitBagSyliusWishlistExtension extends AbstractResourceExtension impl
             return;
         }
 
+        $doctrineConfig = $container->getExtensionConfig('doctrine_migrations');
+        $migrationsPath = (array) \array_pop($doctrineConfig)['migrations_paths'];
         $container->prependExtensionConfig('doctrine_migrations', [
-            'migrations_paths' => [
-                'BitBag\SyliusWishlistPlugin\Migrations' => '@BitBagSyliusWishlistPlugin/Migrations',
-            ],
+            'migrations_paths' => \array_merge(
+                $migrationsPath ?? [],
+                [
+                    'BitBag\SyliusWishlistPlugin\Migrations' => '@BitBagSyliusWishlistPlugin/Migrations',
+                ]
+            ),
         ]);
 
         $container->prependExtensionConfig('sylius_labs_doctrine_migrations_extra', [

--- a/src/Migrations/Version20201029161558.php
+++ b/src/Migrations/Version20201029161558.php
@@ -7,6 +7,9 @@ namespace BitBag\SyliusWishlistPlugin\Migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
+/**
+ * @deprecated Since bitbag/wishlist-plugin 2.0: Doctrine migrations existing in a bundle will be removed, move migrations to the project directory.
+ */
 final class Version20201029161558 extends AbstractMigration
 {
     public function up(Schema $schema): void


### PR DESCRIPTION
Current plugin configuration `v1.5.3` override doctrine_migrations.migrations_paths order for project migration path like `App\Migrations:`

command `debug:config doctrine_migrations` returns
```yaml
doctrine_migrations:
    migrations_paths:
        BitBag\SyliusWishlistPlugin\Migrations: '@BitBagSyliusWishlistPlugin/Migrations'
        App\Migrations: /srv/sylius/src/Migrations
        Sylius\PayPalPlugin\Migrations: '@SyliusPayPalPlugin/Migrations'
        Sylius\Bundle\AdminApiBundle\Migrations: '@SyliusAdminApiBundle/Migrations'
        Sylius\Bundle\CoreBundle\Migrations: '@SyliusCoreBundle/Migrations'
```
should return:
```yaml
doctrine_migrations:
    migrations_paths:
        App\Migrations: /srv/sylius/src/Migrations
        BitBag\SyliusWishlistPlugin\Migrations: '@BitBagSyliusWishlistPlugin/Migrations'
        Sylius\PayPalPlugin\Migrations: '@SyliusPayPalPlugin/Migrations'
        Sylius\Bundle\AdminApiBundle\Migrations: '@SyliusAdminApiBundle/Migrations'
        Sylius\Bundle\CoreBundle\Migrations: '@SyliusCoreBundle/Migrations'

````

fixes #51 