### PR TITLE
Update WishlistContextInterface.php

### DIFF
--- a/src/Context/WishlistContextInterface.php
+++ b/src/Context/WishlistContextInterface.php
@@ -15,5 +15,5 @@ use Symfony\Component\HttpFoundation\Request;
 
 interface WishlistContextInterface
 {
-    public function getWishlist(Request $request): ?WishlistInterface;
+    public function getWishlist(Request $request): WishlistInterface;
 }


### PR DESCRIPTION
`WishlistContext` always returns an instance of `Wishlist` (`WishlistInterface`), so it's probably a good idea to return `WishlistInterface` instead of `?WishlistInterface`.