### PR TITLE
Terminate script before download times out

### DIFF
--- a/src/Controller/Action/ExportWishlistToPdfAction.php
+++ b/src/Controller/Action/ExportWishlistToPdfAction.php
@@ -19,5 +19,8 @@ final class ExportWishlistToPdfAction extends BaseWishlistProductsAction
     {
         $command = new ExportSelectedProductsFromWishlistToPdf($form->getData());
         $this->messageBus->dispatch($command);
+
+        // Preventing downloads timing out. In HTTP proxies without that indicator a timeout will occur.
+        exit();
     }
 }


### PR DESCRIPTION
Terminate script in controller before wishlist pdf download times out. In some HTTP proxies without that indicator a timeout will occur.