### PR TITLE
Improve subscriber performances

### DIFF
--- a/src/Command/RemoveExpiredWishlistsCommand.php
+++ b/src/Command/RemoveExpiredWishlistsCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusWishlistPlugin\Command;
+
+use BitBag\SyliusWishlistPlugin\Repository\WishlistRepositoryInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class RemoveExpiredWishlistsCommand extends Command
+{
+    protected static $defaultName = 'bitbag:wishlist:remove-expired-wishlists';
+    protected static $defaultDescription = 'Removes wishlists that have been idle for a period set in `bit_bag_sylius_wishlist.wishlist_expiration_period` configuration key.';
+
+    private WishlistRepositoryInterface $wishlistRepository;
+    private string $expirationPeriod;
+
+    public function __construct(WishlistRepositoryInterface $wishlistRepository, string $expirationPeriod)
+    {
+        $this->wishlistRepository = $wishlistRepository;
+        $this->expirationPeriod = $expirationPeriod;
+
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if ($io->isVerbose()) {
+            $io->info(sprintf(
+                'Command will remove wishlists that have been idle for %s.',
+                $this->expirationPeriod
+            ));
+        }
+
+        $this->wishlistRepository->deleteWishlistsNotModifiedSince(new \DateTime('-'.$this->expirationPeriod));
+
+        if ($io->isVerbose()) {
+            $io->success('Execution complete.');
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/DependencyInjection/BitBagSyliusWishlistExtension.php
+++ b/src/DependencyInjection/BitBagSyliusWishlistExtension.php
@@ -28,6 +28,7 @@ final class BitBagSyliusWishlistExtension extends AbstractResourceExtension impl
         $this->registerResources('bitbag_sylius_wishlist_plugin', 'doctrine/orm', $config['resources'], $container);
         $loader->load('services.yml');
         $container->setParameter('bitbag_sylius_wishlist_plugin.parameters.wishlist_cookie_token', $config['wishlist_cookie_token']);
+        $container->setParameter('bitbag_sylius_wishlist_plugin.parameters.wishlist_expiration_period', $config['wishlist_expiration_period']);
         $container->setParameter('bitbag_sylius_wishlist_plugin.parameters.allowed_mime_types', $config['allowed_mime_types']);
     }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -101,6 +101,20 @@ final class Configuration implements ConfigurationInterface
                     ->defaultValue('1 month')
                     ->cannotBeEmpty()
                     ->info('Period for which delete old wishlists without products')
+                    ->validate()
+                    ->always(function ($value) {
+                        try {
+                            new \DateTime('-'.$value);
+                        } catch (\Throwable $e) {
+                            throw new InvalidConfigurationException(sprintf(
+                                'The interval "%s" seems to be invalid, please check it\'s value.',
+                                $value
+                            ));
+                        }
+
+                        return $value;
+                    })
+                    ->end()
                 ->end()
             ->end()
         ;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -97,6 +97,11 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->scalarNode('wishlist_expiration_period')
+                    ->defaultValue('1 month')
+                    ->cannotBeEmpty()
+                    ->info('Period for which delete old wishlists without products')
+                ->end()
             ->end()
         ;
 

--- a/src/Entity/Wishlist.php
+++ b/src/Entity/Wishlist.php
@@ -35,7 +35,7 @@ class Wishlist implements WishlistInterface
 
     protected \DateTimeInterface $createdAt;
 
-    protected ?\DateTimeInterface $updatedAt;
+    protected ?\DateTimeInterface $updatedAt = null;
 
     public function __construct()
     {
@@ -197,7 +197,7 @@ class Wishlist implements WishlistInterface
         return $this->createdAt;
     }
 
-    public function getUpdatedAt(): \DateTimeInterface
+    public function getUpdatedAt(): ?\DateTimeInterface
     {
         return $this->updatedAt;
     }

--- a/src/Entity/Wishlist.php
+++ b/src/Entity/Wishlist.php
@@ -33,6 +33,10 @@ class Wishlist implements WishlistInterface
 
     protected ?ChannelInterface $channel;
 
+    protected \DateTimeInterface $createdAt;
+
+    protected ?\DateTimeInterface $updatedAt;
+
     public function __construct()
     {
         $this->wishlistProducts = new ArrayCollection();
@@ -180,5 +184,15 @@ class Wishlist implements WishlistInterface
     public function setChannel(?ChannelInterface $channel): void
     {
         $this->channel = $channel;
+    }
+
+    public function getCreatedAt(): \DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeInterface
+    {
+        return $this->updatedAt;
     }
 }

--- a/src/Entity/Wishlist.php
+++ b/src/Entity/Wishlist.php
@@ -129,6 +129,8 @@ class Wishlist implements WishlistInterface
             $wishlistProduct->setWishlist($this);
             $this->wishlistProducts->add($wishlistProduct);
         }
+
+        $this->updatedAt = new \DateTimeImmutable();
     }
 
     public function getShopUser(): ?ShopUserInterface
@@ -157,6 +159,8 @@ class Wishlist implements WishlistInterface
             $this->wishlistProducts->removeElement($product);
         }
 
+        $this->updatedAt = new \DateTimeImmutable();
+
         return $this;
     }
 
@@ -167,6 +171,8 @@ class Wishlist implements WishlistInterface
                 $this->wishlistProducts->removeElement($wishlistProduct);
             }
         }
+
+        $this->updatedAt = new \DateTimeImmutable();
 
         return $this;
     }

--- a/src/Entity/WishlistInterface.php
+++ b/src/Entity/WishlistInterface.php
@@ -63,4 +63,8 @@ interface WishlistInterface extends ResourceInterface
     public function getChannel(): ?ChannelInterface;
 
     public function setChannel(?ChannelInterface $channel): void;
+
+    public function getCreatedAt(): \DateTimeInterface;
+
+    public function getUpdatedAt(): ?\DateTimeInterface;
 }

--- a/src/EventSubscriber/CreateNewWishlistSubscriber.php
+++ b/src/EventSubscriber/CreateNewWishlistSubscriber.php
@@ -76,10 +76,9 @@ final class CreateNewWishlistSubscriber implements EventSubscriberInterface
             return;
         }
 
-        /** @var WishlistInterface[] $wishlists */
-        $wishlists = $this->wishlistsResolver->resolve();
+        $nbWishlists = $this->wishlistsResolver->count();
 
-        if (!empty($wishlists)) {
+        if (0 < $nbWishlists) {
             return;
         }
 

--- a/src/EventSubscriber/CreateNewWishlistSubscriber.php
+++ b/src/EventSubscriber/CreateNewWishlistSubscriber.php
@@ -66,7 +66,7 @@ final class CreateNewWishlistSubscriber implements EventSubscriberInterface
 
     public function onKernelRequest(RequestEvent $event): void
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 
@@ -87,7 +87,7 @@ final class CreateNewWishlistSubscriber implements EventSubscriberInterface
 
     public function onKernelResponse(ResponseEvent $event): void
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/src/EventSubscriber/CreateNewWishlistSubscriber.php
+++ b/src/EventSubscriber/CreateNewWishlistSubscriber.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Security;
 
 final class CreateNewWishlistSubscriber implements EventSubscriberInterface
 {
@@ -36,7 +36,7 @@ final class CreateNewWishlistSubscriber implements EventSubscriberInterface
 
     private WishlistRepositoryInterface $wishlistRepository;
 
-    private TokenStorageInterface $tokenStorage;
+    private Security $security;
 
     private ChannelContextInterface $channelContext;
 
@@ -45,14 +45,14 @@ final class CreateNewWishlistSubscriber implements EventSubscriberInterface
         WishlistsResolverInterface $wishlistsResolver,
         WishlistFactoryInterface $wishlistFactory,
         WishlistRepositoryInterface $wishlistRepository,
-        TokenStorageInterface $tokenStorage,
+        Security $security,
         ChannelContextInterface $channelContext
     ) {
         $this->wishlistCookieToken = $wishlistCookieToken;
         $this->wishlistsResolver = $wishlistsResolver;
         $this->wishlistFactory = $wishlistFactory;
         $this->wishlistRepository = $wishlistRepository;
-        $this->tokenStorage = $tokenStorage;
+        $this->security = $security;
         $this->channelContext = $channelContext;
     }
 
@@ -112,7 +112,7 @@ final class CreateNewWishlistSubscriber implements EventSubscriberInterface
 
     private function createNewWishlist(?string $wishlistCookieToken): WishlistInterface
     {
-        $user = $this->tokenStorage->getToken() ? $this->tokenStorage->getToken()->getUser() : null;
+        $user = $this->security->getUser();
 
         $wishlist = $this->wishlistFactory->createNew();
 

--- a/src/EventSubscriber/CreateNewWishlistSubscriber.php
+++ b/src/EventSubscriber/CreateNewWishlistSubscriber.php
@@ -70,12 +70,16 @@ final class CreateNewWishlistSubscriber implements EventSubscriberInterface
             return;
         }
 
+        $wishlistCookieToken = $event->getRequest()->cookies->get($this->wishlistCookieToken);
+
+        if ($wishlistCookieToken) {
+            return;
+        }
+
         /** @var WishlistInterface[] $wishlists */
         $wishlists = $this->wishlistsResolver->resolve();
 
-        $wishlistCookieToken = $event->getRequest()->cookies->get($this->wishlistCookieToken);
-
-        if ($wishlistCookieToken && !empty($wishlists)) {
+        if (!empty($wishlists)) {
             return;
         }
 

--- a/src/Repository/WishlistRepository.php
+++ b/src/Repository/WishlistRepository.php
@@ -71,6 +71,20 @@ final class WishlistRepository extends EntityRepository implements WishlistRepos
             ;
     }
 
+    public function countByShopUserAndToken(int $shopUser, string $token): int
+    {
+        return (int) $this
+            ->createQueryBuilder('o')
+            ->select('COUNT(o.id)')
+            ->where('o.shopUser = :shopUser')
+            ->orWhere('o.token = :token')
+            ->setParameter('token', $token)
+            ->setParameter('shopUser', $shopUser)
+            ->getQuery()
+            ->getSingleScalarResult()
+        ;
+    }
+
     public function findAllByAnonymous(?string $token): ?array
     {
         return $this->createQueryBuilder('o')
@@ -80,6 +94,19 @@ final class WishlistRepository extends EntityRepository implements WishlistRepos
             ->getQuery()
             ->getResult()
             ;
+    }
+
+    public function countByAnonymous(?string $token): int
+    {
+        return (int) $this
+            ->createQueryBuilder('o')
+            ->select('COUNT(o.id)')
+            ->where('o.token = :token')
+            ->andWhere('o.shopUser IS NULL')
+            ->setParameter('token', $token)
+            ->getQuery()
+            ->getSingleScalarResult()
+        ;
     }
 
     public function findOneByShopUserAndChannel(
@@ -113,6 +140,26 @@ final class WishlistRepository extends EntityRepository implements WishlistRepos
         }
 
         return $qb->getQuery()->getResult();
+    }
+
+    public function countByAnonymousAndChannel(?string $token, ChannelInterface $channel): int
+    {
+        $qb = $this
+            ->createQueryBuilder('o')
+            ->select('COUNT(o.id)')
+            ->andWhere('o.channel = :channel')
+            ->andWhere('o.shopUser IS NULL')
+            ->setParameter('channel', $channel)
+        ;
+
+        if (null !== $token) {
+            $qb
+                ->andWhere('o.token = :token')
+                ->setParameter('token', $token)
+            ;
+        }
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
     }
 
     public function findOneByTokenAndName(string $token, string $name): ?WishlistInterface

--- a/src/Repository/WishlistRepository.php
+++ b/src/Repository/WishlistRepository.php
@@ -88,6 +88,10 @@ final class WishlistRepository extends EntityRepository implements WishlistRepos
 
     public function findAllByAnonymous(?string $token): ?array
     {
+        if (null === $token) {
+            return [];
+        }
+
         return $this->createQueryBuilder('o')
             ->where('o.token = :token')
             ->andWhere('o.shopUser IS NULL')
@@ -99,6 +103,10 @@ final class WishlistRepository extends EntityRepository implements WishlistRepos
 
     public function countByAnonymous(?string $token): int
     {
+        if (null === $token) {
+            return 0;
+        }
+
         return (int) $this
             ->createQueryBuilder('o')
             ->select('COUNT(o.id)')

--- a/src/Repository/WishlistRepository.php
+++ b/src/Repository/WishlistRepository.php
@@ -14,6 +14,7 @@ use BitBag\SyliusWishlistPlugin\Entity\WishlistInterface;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;
+use Sylius\Component\Order\Model\OrderInterface;
 
 final class WishlistRepository extends EntityRepository implements WishlistRepositoryInterface
 {
@@ -186,5 +187,18 @@ final class WishlistRepository extends EntityRepository implements WishlistRepos
             ->setMaxResults(1)
             ->getOneOrNullResult()
             ;
+    }
+
+    public function deleteWishlistsNotModifiedSince(\DateTimeInterface $period): void
+    {
+        $this
+            ->createQueryBuilder('o')
+            ->delete()
+            ->where('o.updatedAt IS NULL AND o.createdAt < :period')
+            ->orWhere('o.updatedAt < :period')
+            ->setParameter('period', $period)
+            ->getQuery()
+            ->getResult()
+        ;
     }
 }

--- a/src/Repository/WishlistRepositoryInterface.php
+++ b/src/Repository/WishlistRepositoryInterface.php
@@ -27,7 +27,11 @@ interface WishlistRepositoryInterface extends RepositoryInterface
 
     public function findAllByAnonymous(?string $token): ?array;
 
+    public function countByAnonymous(?string $token): int;
+
     public function findAllByShopUserAndToken(int $shopUser, string $token): ?array;
+
+    public function countByShopUserAndToken(int $shopUser, string $token): int;
 
     public function findOneByShopUserAndChannel(
         ShopUserInterface $shopUser,
@@ -35,6 +39,8 @@ interface WishlistRepositoryInterface extends RepositoryInterface
     ): ?WishlistInterface;
 
     public function findAllByAnonymousAndChannel(?string $token, ChannelInterface $channel): ?array;
+
+    public function countByAnonymousAndChannel(?string $token, ChannelInterface $channel): int;
 
     public function findOneByTokenAndName(string $token, string $name): ?WishlistInterface;
 

--- a/src/Repository/WishlistRepositoryInterface.php
+++ b/src/Repository/WishlistRepositoryInterface.php
@@ -45,4 +45,6 @@ interface WishlistRepositoryInterface extends RepositoryInterface
     public function findOneByTokenAndName(string $token, string $name): ?WishlistInterface;
 
     public function findOneByShopUserAndName(ShopUserInterface $shopUser, string $name): ?WishlistInterface;
+
+    public function deleteWishlistsNotModifiedSince(\DateTimeInterface $period): void;
 }

--- a/src/Resolver/WishlistCookieTokenResolver.php
+++ b/src/Resolver/WishlistCookieTokenResolver.php
@@ -29,7 +29,7 @@ final class WishlistCookieTokenResolver implements WishlistCookieTokenResolverIn
 
     public function resolve(): string
     {
-        $wishlistCookieToken = $this->requestStack->getMasterRequest()->cookies->get($this->wishlistCookieToken);
+        $wishlistCookieToken = $this->requestStack->getMainRequest()->cookies->get($this->wishlistCookieToken);
 
         if (!$wishlistCookieToken) {
             return '';

--- a/src/Resolver/WishlistsResolver.php
+++ b/src/Resolver/WishlistsResolver.php
@@ -15,13 +15,13 @@ use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Channel\Context\ChannelNotFoundException;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Security;
 
 final class WishlistsResolver implements WishlistsResolverInterface
 {
     private WishlistRepositoryInterface $wishlistRepository;
 
-    private TokenStorageInterface $tokenStorage;
+    private Security $security;
 
     private WishlistCookieTokenResolverInterface $wishlistCookieTokenResolver;
 
@@ -29,19 +29,19 @@ final class WishlistsResolver implements WishlistsResolverInterface
 
     public function __construct(
         WishlistRepositoryInterface $wishlistRepository,
-        TokenStorageInterface $tokenStorage,
+        Security $security,
         WishlistCookieTokenResolverInterface $wishlistCookieTokenResolver,
         ChannelContextInterface $channelContext
     ) {
         $this->wishlistRepository = $wishlistRepository;
-        $this->tokenStorage = $tokenStorage;
+        $this->security = $security;
         $this->wishlistCookieTokenResolver = $wishlistCookieTokenResolver;
         $this->channelContext = $channelContext;
     }
 
     public function resolve(): array
     {
-        $user = $this->tokenStorage->getToken() ? $this->tokenStorage->getToken()->getUser() : null;
+        $user = $this->security->getUser();
         $wishlistCookieToken = $this->wishlistCookieTokenResolver->resolve();
 
         try {

--- a/src/Resolver/WishlistsResolver.php
+++ b/src/Resolver/WishlistsResolver.php
@@ -43,12 +43,7 @@ final class WishlistsResolver implements WishlistsResolverInterface
     {
         $user = $this->security->getUser();
         $wishlistCookieToken = $this->wishlistCookieTokenResolver->resolve();
-
-        try {
-            $channel = $this->channelContext->getChannel();
-        } catch (ChannelNotFoundException $foundException) {
-            $channel = null;
-        }
+        $channel = $this->getChannel();
 
         if ($user instanceof ShopUserInterface) {
             return $this->wishlistRepository->findAllByShopUserAndToken($user->getId(), $wishlistCookieToken);
@@ -59,5 +54,31 @@ final class WishlistsResolver implements WishlistsResolverInterface
         }
 
         return $this->wishlistRepository->findAllByAnonymous($wishlistCookieToken);
+    }
+
+    public function count(): int
+    {
+        $user = $this->security->getUser();
+        $wishlistCookieToken = $this->wishlistCookieTokenResolver->resolve();
+        $channel = $this->getChannel();
+
+        if ($user instanceof ShopUserInterface) {
+            return $this->wishlistRepository->countByShopUserAndToken($user->getId(), $wishlistCookieToken);
+        }
+
+        if ($channel instanceof ChannelInterface) {
+            return $this->wishlistRepository->countByAnonymousAndChannel($wishlistCookieToken, $channel);
+        }
+
+        return $this->wishlistRepository->countByAnonymous($wishlistCookieToken);
+    }
+
+    private function getChannel(): ?ChannelInterface
+    {
+        try {
+            return $this->channelContext->getChannel();
+        } catch (ChannelNotFoundException $foundException) {
+            return null;
+        }
     }
 }

--- a/src/Resolver/WishlistsResolverInterface.php
+++ b/src/Resolver/WishlistsResolverInterface.php
@@ -13,4 +13,6 @@ namespace BitBag\SyliusWishlistPlugin\Resolver;
 interface WishlistsResolverInterface
 {
     public function resolve(): array;
+
+    public function count(): int;
 }

--- a/src/Resources/config/doctrine/Wishlist.orm.xml
+++ b/src/Resources/config/doctrine/Wishlist.orm.xml
@@ -6,6 +6,10 @@
                                       http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <mapped-superclass name="BitBag\SyliusWishlistPlugin\Entity\Wishlist" table="bitbag_wishlist">
+        <indexes>
+            <index name="token_idx" columns="token" />
+        </indexes>
+
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />
         </id>
@@ -13,8 +17,8 @@
 
         <field name="token" type="string" column="token" />
 
-        <one-to-many field="wishlistProducts" 
-                     target-entity="BitBag\SyliusWishlistPlugin\Entity\WishlistProductInterface" 
+        <one-to-many field="wishlistProducts"
+                     target-entity="BitBag\SyliusWishlistPlugin\Entity\WishlistProductInterface"
                      mapped-by="wishlist" orphan-removal="true"
         >
             <cascade>

--- a/src/Resources/config/doctrine/Wishlist.orm.xml
+++ b/src/Resources/config/doctrine/Wishlist.orm.xml
@@ -2,6 +2,7 @@
 
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping"
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                                       http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
@@ -34,6 +35,12 @@
             <join-column name="channel_id" on-delete="CASCADE" />
         </many-to-one>
 
+        <field name="createdAt" column="created_at" type="datetime">
+            <gedmo:timestampable on="create" />
+        </field>
+        <field name="updatedAt" column="updated_at" type="datetime" nullable="true">
+            <gedmo:timestampable on="update" />
+        </field>
     </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Resources/config/doctrine/Wishlist.orm.xml
+++ b/src/Resources/config/doctrine/Wishlist.orm.xml
@@ -36,6 +36,9 @@
         </many-to-one>
 
         <field name="createdAt" column="created_at" type="datetime">
+            <options>
+                <option name="default">CURRENT_TIMESTAMP</option>
+            </options>
             <gedmo:timestampable on="create" />
         </field>
         <field name="updatedAt" column="updated_at" type="datetime" nullable="true">

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -372,3 +372,11 @@ services:
             - "@security.token_storage"
         tags:
             - { name: controller.service_arguments }
+
+    bitbag_sylius_wishlist_plugin.command.remove_expired_wishlists:
+        class: BitBag\SyliusWishlistPlugin\Command\RemoveExpiredWishlistsCommand
+        arguments:
+            - '@bitbag_sylius_wishlist_plugin.repository.wishlist'
+            - '%bitbag_sylius_wishlist_plugin.parameters.wishlist_expiration_period%'
+        tags:
+            - { name: console.command }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -199,7 +199,7 @@ services:
             - "@bitbag_sylius_wishlist_plugin.resolver.wishlists_resolver"
             - "@bitbag_sylius_wishlist_plugin.factory.wishlist"
             - "@bitbag_sylius_wishlist_plugin.repository.wishlist"
-            - "@security.token_storage"
+            - "@security.helper"
             - "@sylius.context.channel"
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Resources/config/services/resolver.yml
+++ b/src/Resources/config/services/resolver.yml
@@ -10,7 +10,7 @@ services:
         class: BitBag\SyliusWishlistPlugin\Resolver\WishlistsResolver
         arguments:
             - "@bitbag_sylius_wishlist_plugin.repository.wishlist"
-            - "@security.token_storage"
+            - "@security.helper"
             - "@bitbag_sylius_wishlist_plugin.resolver.wishlist_cookie_token_resolver"
             - "@sylius.context.channel"
 


### PR DESCRIPTION
Close #130

Perfectible because we always generate a new wishlist one every request if no cookie is set, but performances are improved because of the new index on token and use of a `COUNT` query instead of getting all entities (which is not necessary in this case).

I would have liked to put the uniqueness back on the token, but I don't want to risk conflicts with custom codes.

I have also add `createdAt` and `updatedAt` columns on wishlist, a configuration value and a Command allowing to remove expired wishlist.