### PR TITLE
fixes debugging from cli for registered event listeners

### DIFF
--- a/src/EventSubscriber/CreateNewWishlistSubscriber.php
+++ b/src/EventSubscriber/CreateNewWishlistSubscriber.php
@@ -40,6 +40,10 @@ final class CreateNewWishlistSubscriber implements EventSubscriberInterface
         WishlistCookieTokenResolverInterface $wishlistCookieTokenResolver,
         RequestStack $requestStack,
     ) {
+        if(php_sapi_name() === 'cli') {
+            return;
+        }
+
         $this->wishlistCookieToken = $wishlistCookieToken;
         $this->wishlistsResolver = $wishlistsResolver;
         $this->wishlistCookieTokenResolver = $wishlistCookieTokenResolver;


### PR DESCRIPTION
currently if you run the command `php bin/console debug:event-dispatcher ` to find out what listeners are registered in your app an error occurring:

```
 In Assert.php line 2074:
                                                 
  The class has to be used in HTTP context only  

```
to fix this I just add a check if the request come from cli before the processing. 