### PR TITLE
Add symfony command to remove expired anonymous wishlists

### DIFF
--- a/doc/01-installation.md
+++ b/doc/01-installation.md
@@ -111,3 +111,14 @@ framework:
 ```
 
 All commands from the plugin implement the `WishlistSyncCommandInterface` interface, so there is no need for other configuration.
+
+## Removing anonymous wishlists after expiration period
+
+You can remove anonymous wishlists that have not been updated for a specified period of time. To do so, you need to add `bitbag:remove-anonymous-wishlists` Symfony console command to your cron jobs.
+
+You can specify the expiration period in your parameters file to override the default value of 30 days:
+
+```yaml
+parameters:
+    bitbag_sylius_wishlist_plugin.parameters.anonymous_wishlist_expiration_period: 30 days # Remove all anonymous wishlists that were updated more than 30 days ago.
+```

--- a/src/Console/RemoveAnonymousWishlistsCommand.php
+++ b/src/Console/RemoveAnonymousWishlistsCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * You can find more information about us on https://bitbag.io and write us
+ * an email on hello@bitbag.io.
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusWishlistPlugin\Console;
+
+use BitBag\SyliusWishlistPlugin\Remover\AnonymousWishlistsRemoverInterface;
+use SyliusLabs\Polyfill\Symfony\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @final
+ */
+class RemoveAnonymousWishlistsCommand extends ContainerAwareCommand
+{
+    protected static $defaultName = 'bitbag:remove-anonymous-wishlists';
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Removes anonymous wishlists that have been idle for a period set in `bitbag_sylius_wishlist_plugin.parameters.anonymous_wishlist_expiration_period` configuration key.')
+            ->setDescription('Removes anonymous wishlists that have been idle for a period set in `bitbag_sylius_wishlist_plugin.parameters.anonymous_wishlist_expiration_period` configuration key.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var string $expirationTime */
+        $expirationTime = $this->getContainer()->getParameter('bitbag_sylius_wishlist_plugin.parameters.anonymous_wishlist_expiration_period');
+
+        if (empty($expirationTime)) {
+            $output->writeln('<error>`bitbag_sylius_wishlist_plugin.parameters.anonymous_wishlist_expiration_period` configuration key is not set, so no wishlists will be removed.</error>');
+
+            return 0;
+        }
+
+        $output->writeln(sprintf(
+            'Command will remove anonymous wishlists that have been idle for <info>%s</info>.',
+            (string) $expirationTime,
+        ));
+
+        /** @var AnonymousWishlistsRemoverInterface $anonymousWishlistsRemover */
+        $anonymousWishlistsRemover = $this->getContainer()->get('bitbag_sylius_wishlist_plugin.services.anonymous_wishlists_remover');
+        $anonymousWishlistsRemover->remove();
+
+        return 0;
+    }
+}

--- a/src/DependencyInjection/BitBagSyliusWishlistExtension.php
+++ b/src/DependencyInjection/BitBagSyliusWishlistExtension.php
@@ -29,6 +29,7 @@ final class BitBagSyliusWishlistExtension extends AbstractResourceExtension impl
         $this->registerResources('bitbag_sylius_wishlist_plugin', 'doctrine/orm', $config['resources'], $container);
         $loader->load('services.yml');
         $container->setParameter('bitbag_sylius_wishlist_plugin.parameters.wishlist_cookie_token', $config['wishlist_cookie_token']);
+        $container->setParameter('bitbag_sylius_wishlist_plugin.parameters.anonymous_wishlist_expiration_period', $config['anonymous_wishlist_expiration_period']);
         $container->setParameter('bitbag_sylius_wishlist_plugin.parameters.allowed_mime_types', $config['allowed_mime_types']);
     }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -45,6 +45,19 @@ final class Configuration implements ConfigurationInterface
                         })
                     ->end()
                 ->end()
+                ->scalarNode('anonymous_wishlist_expiration_period')
+                    ->defaultValue('30 days')
+                    ->cannotBeEmpty()
+                    ->validate()
+                        ->always(function ($value) {
+                            if (!is_string($value)) {
+                                throw new InvalidConfigurationException('anonymous_wishlist_expiration_period must be string');
+                            }
+
+                            return $value;
+                        })
+                    ->end()
+                ->end()
                 ->arrayNode('allowed_mime_types')
                     ->defaultValue([
                         'text/csv',

--- a/src/Remover/AnonymousWishlistsRemover.php
+++ b/src/Remover/AnonymousWishlistsRemover.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * You can find more information about us on https://bitbag.io and write us
+ * an email on hello@bitbag.io.
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusWishlistPlugin\Remover;
+
+use BitBag\SyliusWishlistPlugin\Repository\WishlistRepositoryInterface;
+use Doctrine\Persistence\ObjectManager;
+
+final class AnonymousWishlistsRemover implements AnonymousWishlistsRemoverInterface
+{
+    public function __construct(
+        private WishlistRepositoryInterface $wishlistRepository,
+        private ObjectManager $wishlistManager,
+        private ?string $expirationPeriod,
+    ) {
+    }
+
+    public function remove(): void
+    {
+        $this->wishlistRepository->deleteAllAnonymousUntil(
+            new \DateTime('-' . $this->expirationPeriod),
+        );
+    }
+}

--- a/src/Remover/AnonymousWishlistsRemoverInterface.php
+++ b/src/Remover/AnonymousWishlistsRemoverInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * You can find more information about us on https://bitbag.io and write us
+ * an email on hello@bitbag.io.
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusWishlistPlugin\Remover;
+
+interface AnonymousWishlistsRemoverInterface
+{
+    public function remove(): void;
+}

--- a/src/Repository/WishlistRepository.php
+++ b/src/Repository/WishlistRepository.php
@@ -145,4 +145,16 @@ class WishlistRepository extends EntityRepository implements WishlistRepositoryI
             ->getOneOrNullResult()
         ;
     }
+
+    public function deleteAllAnonymousUntil(\DateTime $until): int
+    {
+        return $this->createQueryBuilder('o')
+            ->delete(WishlistInterface::class, 'o')
+            ->where('o.shopUser IS NULL')
+            ->andWhere('o.updatedAt < :until')
+            ->setParameter('until', $until)
+            ->getQuery()
+            ->execute()
+        ;
+    }
 }

--- a/src/Repository/WishlistRepositoryInterface.php
+++ b/src/Repository/WishlistRepositoryInterface.php
@@ -40,4 +40,9 @@ interface WishlistRepositoryInterface extends RepositoryInterface
     public function findOneByTokenAndName(string $token, string $name): ?WishlistInterface;
 
     public function findOneByShopUserAndName(ShopUserInterface $shopUser, string $name): ?WishlistInterface;
+
+    /**
+     * @return int Number of deleted wishlists.
+     */
+    public function deleteAllAnonymousUntil(\DateTime $until): int;
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -2,6 +2,11 @@ imports:
     - { resource: "services/**/*.yml" }
 
 services:
+    bitbag_sylius_wishlist_plugin.console.remove_anonymous_wishlists_command:
+        class: BitBag\SyliusWishlistPlugin\Console\RemoveAnonymousWishlistsCommand
+        tags:
+            - { name: console.command }
+
     bitbag_sylius_wishlist_plugin.controller.action.base_wishlist_products_action:
         abstract: true
         class: BitBag\SyliusWishlistPlugin\Controller\Action\BaseWishlistProductsAction
@@ -347,6 +352,14 @@ services:
             - "@bitbag_sylius_wishlist_plugin.repository.wishlist"
             - '@request_stack'
             - "@translator"
+
+    bitbag_sylius_wishlist_plugin.services.anonymous_wishlists_remover:
+        public: true
+        class: BitBag\SyliusWishlistPlugin\Remover\AnonymousWishlistsRemover
+        arguments:
+            - "@bitbag_sylius_wishlist_plugin.repository.wishlist"
+            - "@bitbag_sylius_wishlist_plugin.manager.wishlist"
+            - "%bitbag_sylius_wishlist_plugin.parameters.anonymous_wishlist_expiration_period%"
 
     bitbag_sylius_wishlist_plugin.checker.wishlist_name_checker:
         class: BitBag\SyliusWishlistPlugin\Checker\WishlistNameChecker

--- a/tests/Integration/DataFixtures/ORM/test_it_delete_all_anonymous_until_wishlists.yaml
+++ b/tests/Integration/DataFixtures/ORM/test_it_delete_all_anonymous_until_wishlists.yaml
@@ -1,0 +1,46 @@
+Sylius\Component\Locale\Model\Locale:
+    locale:
+        createdAt: '<dateTimeBetween("-200 days", "now")>'
+        code: 'en_US'
+Sylius\Component\Currency\Model\Currency:
+    dollar:
+        code: 'USD'
+Sylius\Component\Core\Model\Channel:
+    channel_us:
+        code: 'US'
+        name: 'name'
+        defaultLocale: '@locale'
+        locales: [ '@locale' ]
+        taxCalculationStrategy: 'order_items_based'
+        baseCurrency: '@dollar'
+        enabled: true
+Sylius\Component\Core\Model\Customer:
+    customer_oliver:
+        firstName: 'John'
+        lastName: 'Nowak'
+        email: 'oliver@queen.com'
+        emailCanonical: 'test2@example.com'
+Sylius\Component\Core\Model\ShopUser:
+    user_oliver:
+        plainPassword: '123password'
+        roles: [ 'ROLE_USER' ]
+        enabled: 'true'
+        customer: '@customer_oliver'
+        username: 'oliver@queen.com'
+        usernameCanonical: 'oliver@queen.com'
+BitBag\SyliusWishlistPlugin\Entity\Wishlist:
+    wishlist_one:
+        name: 'Wishlist One'
+        channel: '@channel_us'
+        token: 'token'
+        updatedAt: '<date_create_from_format("Y-m-d H:i:s", "2023-01-01 00:00:00")>'
+    wishlist_two:
+        name: 'Wishlist Two'
+        channel: '@channel_us'
+        token: 'token'
+        updatedAt: '<date_create_from_format("Y-m-d H:i:s", "2024-01-02 00:00:00")>'
+    olivier_wishlist:
+        name: 'Olivier Wishlist'
+        shopUser: '@user_oliver'
+        channel: '@channel_us'
+        updatedAt: '<date_create_from_format("Y-m-d H:i:s", "2023-01-01 00:00:00")>'

--- a/tests/Integration/Repository/WishlistRepositoryTest.php
+++ b/tests/Integration/Repository/WishlistRepositoryTest.php
@@ -182,4 +182,20 @@ final class WishlistRepositoryTest extends JsonApiTestCase
         $missingResult = $this->repository->findOneByShopUserAndName($shopUser, 'Bruce Wishlist');
         $this->assertNull($missingResult);
     }
+
+    public function testItDeleteAllAnonymousUntilWishlists(): void
+    {
+        $this->loadFixturesFromFile('test_it_delete_all_anonymous_until_wishlists.yaml');
+
+        /** @var int $result */
+        $result = $this->repository->deleteAllAnonymousUntil(new \DateTime('2024-01-01 00:00:00'));
+
+        $this->assertIsInt($result);
+        $this->assertSame(1, $result);
+
+        $wishlists = $this->repository->findAll();
+        $this->assertCount(2, $wishlists);
+        $this->assertSame('Wishlist Two', $wishlists[0]->getName());
+        $this->assertSame('Olivier Wishlist', $wishlists[1]->getName());
+    }
 }


### PR DESCRIPTION
A wishlist is created for each guest or shop user. In the case of a high-traffic site, the number of guest users will considerably increase the number of wishlists created.

In the same spirit as the "remove expired cart" command provided by Sylius, this PR introduces a command to delete guest user wishlists after a configurable period via the `bitbag_sylius_wishlist_plugin.parameters.anonymous_wishlist_expiration_period` parameter.

Idea emerging from https://github.com/BitBagCommerce/SyliusWishlistPlugin/issues/130#issuecomment-1683035539.